### PR TITLE
Add Linux runtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ venv/
 .venv/
 env/
 .env
+AgnetPark_Linux_env/
 .runtime/
 .cache/
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ AgentPark/
 ## Requirements
 
 - Windows is the primary target environment. Some features depend on `.bat`, PowerShell, desktop automation, or PyInstaller packaging paths.
-- Python 3.11+. Project scripts prefer local Python 3.14/3.12/3.11 when available, and can also use `python`.
+- Linux is supported for the WebUI, CLI, provider runtime, and restart flow. Windows-only desktop and packaging features remain Windows-only.
+- Python 3.11+. Windows scripts prefer local Python 3.14/3.12/3.11; Linux scripts prefer `AgnetPark_Linux_env`, `.venv`, `python3`, then `python`.
 - Node.js + npm for installing and building `webui`.
 - ripgrep `rg` is recommended; file search tools and some frontend search paths prefer it.
 
@@ -186,7 +187,13 @@ On Windows, the recommended entry is:
 build_and_run.bat
 ```
 
-This script:
+On Linux, use:
+
+```sh
+./build_and_run.sh
+```
+
+Both platform scripts:
 
 - Checks Python and `rg`.
 - Installs missing frontend dependencies.
@@ -256,7 +263,13 @@ On Windows, run:
 Restart.bat
 ```
 
-The script attempts to stop the current AgentPark service, run `git pull --rebase`, and restart through `build_and_run.bat`.
+On Linux, run:
+
+```sh
+./Restart.sh
+```
+
+The platform restart script attempts to stop the current AgentPark service, update a clean working tree, and restart through the matching build-and-run script.
 
 The WebUI can also call `/api/system/restart` to trigger the restart flow.
 
@@ -348,11 +361,11 @@ memories/Companion/Companion/memory.md
 memories/Companion/Companion/messages.jsonl
 ```
 
-After the normal build/install flow, `build_and_run.bat` starts the WebUI server in the background, opens the browser from that server process, and then starts the interactive companion CLI in the current terminal. `build_and_run.bat cli` and `build_and_run.bat chat` use the same combined Web + CLI startup. Use `build_and_run.bat server` or `build_and_run.bat web` when only the WebUI server should run, and `build_and_run.bat cli-only` when the CLI should run without starting WebUI.
+After the normal build/install flow, `build_and_run.bat` on Windows or `build_and_run.sh` on Linux starts the WebUI server in the background and then starts the interactive companion CLI in the current terminal. The `cli` and `chat` modes use the combined Web + CLI startup. Use `server` or `web` for WebUI only, and `cli-only` for CLI without WebUI.
 
-The companion CLI runs the same Agent turn path as normal nodes and stores state in `memories/Companion/Companion/`. If the terminal does not accept input, run `build_and_run.bat cli --debug-terminal`; interactive input diagnostics fail loudly instead of silently downgrading.
+The companion CLI runs the same Agent turn path as normal nodes and stores state in `memories/Companion/Companion/`. If the terminal does not accept input, run the platform build-and-run script with `cli --debug-terminal`; interactive input diagnostics fail loudly instead of silently downgrading.
 
-Inside the companion CLI, `/restart` launches the repository `Restart.bat` and exits the current CLI session so restart behavior stays on the canonical startup path.
+Inside the companion CLI, `/restart` launches `Restart.bat` on Windows or `Restart.sh` on Linux and exits the current CLI session so restart behavior stays on the canonical startup path.
 
 Node config reads and writes are documented in `docs/config-contract.md`. Runtime state recovery is documented in `docs/runtime-state-machine.md`. Provider feature support is documented in `docs/provider-feature-matrix.md`. Capability descriptors and dependency reporting are documented in `docs/capability-system.md`. Skill/plugin authoring is documented in `docs/skill-plugin-authoring.md`. Long-term sidecar, caching, and distribution boundaries are documented in `docs/long-term-architecture.md`. Recovery steps are documented in `docs/troubleshooting.md`.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -114,7 +114,8 @@ AgentPark/
 ## 环境要求
 
 - Windows 是主要目标环境。部分功能依赖 `.bat`、PowerShell、桌面自动化或 PyInstaller 打包路径。
-- Python 3.11+。项目脚本会优先使用本地 Python 3.14/3.12/3.11，也可以使用 `python`。
+- Linux 支持 WebUI、CLI、provider runtime 和重启流程；Windows 桌面与打包功能仍仅支持 Windows。
+- Python 3.11+。Windows 脚本优先使用本地 Python 3.14/3.12/3.11；Linux 脚本依次尝试 `AgnetPark_Linux_env`、`.venv`、`python3` 和 `python`。
 - Node.js + npm，用于安装和构建 `webui`。
 - 推荐安装 ripgrep `rg`；文件搜索工具和部分前端搜索路径会优先使用它。
 
@@ -186,7 +187,13 @@ Windows 下推荐入口：
 build_and_run.bat
 ```
 
-该脚本会：
+Linux 下使用：
+
+```sh
+./build_and_run.sh
+```
+
+两个平台脚本都会：
 
 - 检查 Python 和 `rg`。
 - 安装缺失的前端依赖。
@@ -256,7 +263,13 @@ Windows 下运行：
 Restart.bat
 ```
 
-脚本会尝试停止当前 AgentPark 服务，执行 `git pull --rebase`，并通过 `build_and_run.bat` 重启。
+Linux 下运行：
+
+```sh
+./Restart.sh
+```
+
+对应平台的重启脚本会尝试停止当前 AgentPark 服务，在工作区干净时更新代码，并通过对应的构建启动脚本重启。
 
 WebUI 也可以调用 `/api/system/restart` 触发重启流程。
 
@@ -348,11 +361,11 @@ memories/Companion/Companion/memory.md
 memories/Companion/Companion/messages.jsonl
 ```
 
-正常构建/安装流程完成后，`build_and_run.bat` 会在后台启动 WebUI 服务，由该服务进程打开浏览器，然后在当前终端启动交互式 companion CLI。`build_and_run.bat cli` 和 `build_and_run.bat chat` 使用相同的 Web + CLI 组合启动方式。只运行 WebUI 服务时使用 `build_and_run.bat server` 或 `build_and_run.bat web`；只运行 CLI 且不启动 WebUI 时使用 `build_and_run.bat cli-only`。
+正常构建/安装流程完成后，Windows 使用 `build_and_run.bat`，Linux 使用 `build_and_run.sh`；脚本会在后台启动 WebUI 服务，然后在当前终端启动交互式 companion CLI。`cli` 和 `chat` 使用 Web + CLI 组合模式；`server` 或 `web` 只运行 WebUI；`cli-only` 只运行 CLI。
 
-companion CLI 使用与普通节点相同的 Agent turn 流程，并把状态存储在 `memories/Companion/Companion/`。如果终端不接受输入，运行 `build_and_run.bat cli --debug-terminal`；交互式输入诊断会明确失败，而不是静默降级。
+companion CLI 使用与普通节点相同的 Agent turn 流程，并把状态存储在 `memories/Companion/Companion/`。如果终端不接受输入，使用对应平台的构建启动脚本运行 `cli --debug-terminal`；交互式输入诊断会明确失败，而不是静默降级。
 
-在 companion CLI 中，`/restart` 会启动仓库中的 `Restart.bat` 并退出当前 CLI 会话，确保重启行为仍走标准启动路径。
+在 companion CLI 中，`/restart` 会在 Windows 启动 `Restart.bat`，在 Linux 启动 `Restart.sh`，然后退出当前 CLI 会话，确保重启行为仍走标准启动路径。
 
 节点配置读写见 `docs/config-contract.md`。运行时状态恢复见 `docs/runtime-state-machine.md`。服务商功能支持见 `docs/provider-feature-matrix.md`。能力描述符和依赖报告见 `docs/capability-system.md`。Skill/plugin 作者指南见 `docs/skill-plugin-authoring.md`。长期 sidecar、缓存和分发边界见 `docs/long-term-architecture.md`。恢复步骤见 `docs/troubleshooting.md`。
 

--- a/Restart.sh
+++ b/Restart.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")"
+WORKSPACE_ROOT="$(pwd)"
+PYTHON_BIN="${PYTHON_BIN:-}"
+
+if [ -z "$PYTHON_BIN" ]; then
+  for candidate in "$WORKSPACE_ROOT/AgnetPark_Linux_env/bin/python" "$WORKSPACE_ROOT/.venv/bin/python" python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -m pip --version >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$PYTHON_BIN" ]; then
+  echo "[ERROR] Could not find a Python interpreter with pip available." >&2
+  exit 1
+fi
+
+echo "[INFO] Restarting AgentPark..."
+"$PYTHON_BIN" scripts/restart_aitools.py --workspace-root "$WORKSPACE_ROOT" --stop-only
+
+if git status --porcelain | grep . >/dev/null 2>&1; then
+  echo "[WARN] Working tree has local changes; skipping git pull --rebase."
+else
+  echo "[INFO] Updating repository with git pull --rebase..."
+  git pull --rebase || echo "[WARN] git pull --rebase failed; continuing startup with current workspace."
+fi
+
+echo "[INFO] Starting AgentPark through build_and_run.sh..."
+AITOOLS_NO_PAUSE=1 exec "$WORKSPACE_ROOT/build_and_run.sh" "$@"

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")"
+
+LAUNCH_MODE="cli_web"
+CLI_ARGS="chat"
+RESTART_EXIT_CODE="43"
+PYTHON_BIN="${PYTHON_BIN:-}"
+SERVER_PID=""
+EXPLICIT_MODE="0"
+
+export PYTHONUTF8=1
+export PYTHONIOENCODING=utf-8
+
+case "${1:-}" in
+  server|web)
+    EXPLICIT_MODE="1"
+    LAUNCH_MODE="server"
+    CLI_ARGS=""
+    ;;
+  cli-only)
+    EXPLICIT_MODE="1"
+    LAUNCH_MODE="cli_only"
+    shift || true
+    case "${1:-}" in
+      "" )
+        CLI_ARGS="chat"
+        ;;
+      chat|doctor|capabilities|config)
+        CLI_ARGS="$*"
+        ;;
+      *)
+        CLI_ARGS="chat $*"
+        ;;
+    esac
+    ;;
+  cli)
+    EXPLICIT_MODE="1"
+    LAUNCH_MODE="cli_web"
+    shift || true
+    case "${1:-}" in
+      "" )
+        CLI_ARGS="chat"
+        ;;
+      chat|doctor|capabilities|config)
+        CLI_ARGS="$*"
+        ;;
+      *)
+        CLI_ARGS="chat $*"
+        ;;
+    esac
+    ;;
+  chat)
+    EXPLICIT_MODE="1"
+    LAUNCH_MODE="cli_web"
+    shift || true
+    CLI_ARGS="chat ${*:-}"
+    ;;
+esac
+
+if [ "$EXPLICIT_MODE" = "0" ] && { [ ! -t 0 ] || [ ! -t 1 ]; }; then
+  echo "[INFO] Non-interactive terminal detected; starting server only. Use './build_and_run.sh cli' from an interactive terminal for companion chat."
+  LAUNCH_MODE="server"
+  CLI_ARGS=""
+fi
+
+select_python() {
+  if [ -n "$PYTHON_BIN" ]; then
+    return 0
+  fi
+  for candidate in "./AgnetPark_Linux_env/bin/python" "./.venv/bin/python" "python3" "python"; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -m pip --version >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+stop_background_server() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+select_python || {
+  echo "[ERROR] Could not find a Python interpreter with pip available." >&2
+  exit 1
+}
+
+echo "[INFO] Using Python: $PYTHON_BIN"
+if ! command -v rg >/dev/null 2>&1; then
+  echo "[WARN] ripgrep (rg) not found in PATH. Shell rg commands will be unavailable."
+fi
+
+echo "[INFO] Installing/updating WebUI dependencies..."
+cd webui
+npm install
+
+echo "[INFO] Compiling WebUI..."
+npm run build
+cd ..
+
+echo "[INFO] Installing/updating Python dependencies..."
+"$PYTHON_BIN" -m pip install -e .
+
+if [ "$LAUNCH_MODE" = "cli_web" ]; then
+  echo "[INFO] Stopping existing AgentPark processes for this workspace..."
+  "$PYTHON_BIN" scripts/restart_aitools.py --workspace-root "$(pwd)" --stop-only
+
+  mkdir -p .runtime
+  echo "[INFO] Starting AgentPark web server in background."
+  "$PYTHON_BIN" -m src.fast_api --workspace-root "$(pwd)" > .runtime/aitools-server.log 2> .runtime/aitools-server.err.log &
+  SERVER_PID="$!"
+  trap stop_background_server EXIT INT TERM
+fi
+
+if [ "$LAUNCH_MODE" = "cli_web" ] || [ "$LAUNCH_MODE" = "cli_only" ]; then
+  echo "[INFO] Starting AgentPark CLI: python -m src.cli $CLI_ARGS"
+  set +e
+  "$PYTHON_BIN" -m src.cli $CLI_ARGS
+  code="$?"
+  set -e
+  if [ "$code" = "$RESTART_EXIT_CODE" ]; then
+    exit 0
+  fi
+  exit "$code"
+fi
+
+echo "[INFO] Starting AgentPark server..."
+exec "$PYTHON_BIN" -m src.fast_api --workspace-root "$(pwd)"

--- a/docs/linux-merge-acceptance.md
+++ b/docs/linux-merge-acceptance.md
@@ -1,0 +1,69 @@
+# Linux Merge Acceptance
+
+This repository carries Linux-port changes on top of an upstream Windows-first
+AgentPark codebase. After pulling or rebasing upstream changes, run the Linux
+acceptance script before treating the merge as complete.
+
+## Commands
+
+Fast local gate:
+
+```sh
+scripts/acceptance_linux.sh --quick
+```
+
+Full local gate:
+
+```sh
+scripts/acceptance_linux.sh --full
+```
+
+Skip the WebUI build when only backend contracts changed:
+
+```sh
+AGENTPARK_ACCEPTANCE_SKIP_FRONTEND_BUILD=1 scripts/acceptance_linux.sh --full
+```
+
+Skip provider factory construction only when local provider credentials are not
+available:
+
+```sh
+scripts/acceptance_linux.sh --skip-provider-factory
+```
+
+## What It Checks
+
+- unresolved git conflicts and committed conflict markers
+- JSON validity for local runtime configuration files
+- provider type compatibility with `src.providers.create_agent`
+- backend import health
+- focused provider, config, Responses, memory, mobile, skills, MCP, plugin, and
+  tool protocol tests
+- optional WebUI production build
+- required Linux shell scripts are executable
+
+The checks are intentionally local and offline. They should not send real model
+requests or depend on upstream provider availability.
+
+## What It Cannot Guarantee
+
+This gate does not make a large upstream refactor conflict-free. It cannot know
+whether a manually resolved conflict preserved every intended behavior.
+
+Its job is to make common Linux-port regressions visible immediately after a
+merge: unsupported provider types, Windows-only command residue, broken config
+contracts, frontend build failures, and broken extension loaders.
+
+When upstream changes are structurally large, resolve the merge first, then run
+`--quick`. If it passes, run `--full`. If `--full` fails, classify the failure as
+one of these before patching:
+
+- merge conflict residue
+- provider/config contract mismatch
+- platform/runtime issue
+- frontend build issue
+- skills, MCP, plugin, tool, memory, or mobile API contract breakage
+- external provider outage, if and only if a real provider request was made
+
+Do not mask those failures with permissive fallbacks. Fix the owning contract or
+module directly.

--- a/functions/capture_screenshot_tools.py
+++ b/functions/capture_screenshot_tools.py
@@ -15,7 +15,7 @@ _SUPPORTED_BACKENDS = {"gdi", "pyautogui", "auto"}
 def capture_screenshot(
     capture_region=None,
     image_format="png",
-    backend="gdi",
+    backend="auto",
     png_compress_level=1,
     jpeg_quality=92,
     agent=None,
@@ -149,7 +149,7 @@ capture_screenshot_declaration = {
         "name": "capture_screenshot",
         "description": (
             "Capture a local desktop screenshot and return the image directly to the model. "
-            "Uses fast Windows GDI by default and does not write image files."
+            "Uses the best available local screenshot backend and does not write image files."
         ),
         "parameters": {
             "type": "object",
@@ -178,7 +178,7 @@ capture_screenshot_declaration = {
                     "type": "string",
                     "enum": ["gdi", "pyautogui", "auto"],
                     "description": "Capture backend. gdi is fastest on Windows; auto tries gdi then pyautogui.",
-                    "default": "gdi",
+                    "default": "auto",
                 },
                 "png_compress_level": {
                     "type": "integer",

--- a/scripts/acceptance_linux.py
+++ b/scripts/acceptance_linux.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_PROVIDER_TYPES = {"openai", "doubao", "claude", "gemini", "zhipu", "hyper3d"}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _check_json_files(root: Path) -> list[str]:
+    errors: list[str] = []
+    for relative in (
+        "config/config.json",
+        "config/moduleProvider.json",
+        "config/ProviderLimit.json",
+    ):
+        path = root / relative
+        if not path.exists():
+            errors.append(f"missing JSON file: {relative}")
+            continue
+        try:
+            _load_json(path)
+        except Exception as exc:
+            errors.append(f"invalid JSON in {relative}: {exc}")
+    return errors
+
+
+def _providers_from_config(root: Path) -> dict[str, dict[str, Any]]:
+    payload = _load_json(root / "config/moduleProvider.json")
+    providers = payload.get("providers") if isinstance(payload, dict) else None
+    return providers if isinstance(providers, dict) else {}
+
+
+def _check_provider_types(providers: dict[str, dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    for provider_id, provider in sorted(providers.items()):
+        provider_type = str((provider or {}).get("type") or "").strip().lower()
+        if provider_type not in SUPPORTED_PROVIDER_TYPES:
+            errors.append(
+                f"provider {provider_id!r} has unsupported type {provider_type!r}; "
+                f"supported={sorted(SUPPORTED_PROVIDER_TYPES)}"
+            )
+    return errors
+
+
+def _check_loader_contract(root: Path) -> list[str]:
+    errors: list[str] = []
+    os.environ["AGENTPARK_CONFIG_PATH"] = str(root / "config/moduleProvider.json")
+    try:
+        from src.config_loader import ConfigLoader
+
+        providers = ConfigLoader().get_all_providers()
+    except Exception as exc:
+        return [f"ConfigLoader failed for local provider config: {type(exc).__name__}: {exc}"]
+    if not isinstance(providers, dict) or not providers:
+        errors.append("ConfigLoader returned no providers")
+    return errors
+
+
+def _check_provider_factory(root: Path, providers: dict[str, dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    os.environ["AGENTPARK_CONFIG_PATH"] = str(root / "config/moduleProvider.json")
+    try:
+        from src.providers import create_agent
+    except Exception as exc:
+        return [f"failed to import provider factory: {type(exc).__name__}: {exc}"]
+
+    skipped_missing_key: list[str] = []
+    for provider_id, provider in sorted(providers.items()):
+        if not str((provider or {}).get("apiKey") or "").strip():
+            skipped_missing_key.append(provider_id)
+            continue
+        try:
+            create_agent(provider_id, internal_memory_enabled=False)
+        except Exception as exc:
+            errors.append(f"create_agent({provider_id!r}) failed: {type(exc).__name__}: {exc}")
+    if skipped_missing_key:
+        print(
+            "[WARN] provider factory creation skipped for providers without apiKey: "
+            + ", ".join(skipped_missing_key),
+            file=sys.stderr,
+        )
+    return errors
+
+
+def _check_executable_scripts(root: Path) -> list[str]:
+    errors: list[str] = []
+    for relative in ("Restart.sh", "build_and_run.sh", "scripts/acceptance_linux.sh"):
+        path = root / relative
+        if not path.exists():
+            errors.append(f"missing executable script: {relative}")
+            continue
+        mode = path.stat().st_mode
+        if not (mode & stat.S_IXUSR):
+            errors.append(f"script is not executable: {relative}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="AgentPark Linux acceptance contract checks.")
+    parser.add_argument(
+        "--skip-provider-factory",
+        action="store_true",
+        help="Skip create_agent checks for local provider entries.",
+    )
+    args = parser.parse_args()
+
+    root = _repo_root()
+    providers = _providers_from_config(root)
+    errors: list[str] = []
+    errors.extend(_check_json_files(root))
+    errors.extend(_check_provider_types(providers))
+    errors.extend(_check_loader_contract(root))
+    errors.extend(_check_executable_scripts(root))
+    if not args.skip_provider_factory:
+        errors.extend(_check_provider_factory(root, providers))
+
+    if errors:
+        print("[FAIL] Linux acceptance contract checks failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("[OK] Linux acceptance contract checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acceptance_linux.sh
+++ b/scripts/acceptance_linux.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-}"
+MODE="full"
+SKIP_FRONTEND_BUILD="${AGENTPARK_ACCEPTANCE_SKIP_FRONTEND_BUILD:-0}"
+SKIP_PROVIDER_FACTORY="${AGENTPARK_ACCEPTANCE_SKIP_PROVIDER_FACTORY:-0}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/acceptance_linux.sh [--quick|--full] [--skip-frontend-build] [--skip-provider-factory]
+
+Runs local Linux merge acceptance checks without calling real model/provider APIs.
+
+Modes:
+  --quick  config/provider contracts + focused core tests
+  --full   quick checks + frontend build + wider skills/MCP/plugin/tool/runtime tests
+
+Environment:
+  PYTHON_BIN                               Python interpreter override
+  AGENTPARK_ACCEPTANCE_SKIP_FRONTEND_BUILD Set to 1 to skip npm run build
+  AGENTPARK_ACCEPTANCE_SKIP_PROVIDER_FACTORY Set to 1 to skip create_agent checks
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --quick)
+      MODE="quick"
+      ;;
+    --full)
+      MODE="full"
+      ;;
+    --skip-frontend-build)
+      SKIP_FRONTEND_BUILD="1"
+      ;;
+    --skip-provider-factory)
+      SKIP_PROVIDER_FACTORY="1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+select_python() {
+  if [ -n "$PYTHON_BIN" ]; then
+    return 0
+  fi
+  for candidate in "$ROOT_DIR/AgnetPark_Linux_env/bin/python" "$ROOT_DIR/.venv/bin/python" python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -m pip --version >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_step() {
+  name="$1"
+  shift
+  echo
+  echo "==> $name"
+  "$@"
+}
+
+run_pytest() {
+  "$PYTHON_BIN" -m pytest "$@"
+}
+
+cd "$ROOT_DIR"
+
+select_python || {
+  echo "[ERROR] Could not find a Python interpreter with pip available." >&2
+  exit 1
+}
+
+echo "[INFO] AgentPark Linux acceptance mode: $MODE"
+echo "[INFO] Python: $PYTHON_BIN"
+
+if git diff --name-only --diff-filter=U | grep . >/dev/null 2>&1; then
+  echo "[ERROR] Unresolved git conflicts are present:" >&2
+  git diff --name-only --diff-filter=U >&2
+  exit 1
+fi
+
+if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- ':!webui/dist/**' ':!*.lock' >/tmp/agentpark_acceptance_conflicts.$$ 2>/dev/null; then
+  echo "[ERROR] Conflict markers found:" >&2
+  cat /tmp/agentpark_acceptance_conflicts.$$ >&2
+  rm -f /tmp/agentpark_acceptance_conflicts.$$
+  exit 1
+fi
+rm -f /tmp/agentpark_acceptance_conflicts.$$
+
+PROVIDER_FACTORY_ARG=""
+if [ "$SKIP_PROVIDER_FACTORY" = "1" ]; then
+  PROVIDER_FACTORY_ARG="--skip-provider-factory"
+fi
+
+run_step "local config and provider contract checks" "$PYTHON_BIN" scripts/acceptance_linux.py $PROVIDER_FACTORY_ARG
+run_step "backend import smoke" "$PYTHON_BIN" -c "import src.fast_api; import src.config_loader; import src.providers; print('backend imports OK')"
+
+if [ "$SKIP_FRONTEND_BUILD" != "1" ] && [ "$MODE" = "full" ]; then
+  run_step "WebUI build" npm --prefix webui run build
+else
+  echo
+  echo "==> WebUI build"
+  echo "[SKIP] skipped by mode or AGENTPARK_ACCEPTANCE_SKIP_FRONTEND_BUILD"
+fi
+
+run_step "core contract tests" run_pytest \
+  tests/test_config_loader.py \
+  tests/test_provider_factory.py \
+  tests/test_agent_node_config.py \
+  tests/test_agent_node_stream.py \
+  tests/test_openai_responses_runtime.py \
+  tests/test_responses_websocket_transport.py
+
+if [ "$MODE" = "full" ]; then
+  run_step "extension contract tests" run_pytest \
+    tests/test_agent_mcp_loader.py \
+    tests/test_agent_plugin_loader.py \
+    tests/test_agent_tool_loader.py \
+    tests/test_agent_skill_loader.py \
+    tests/test_skill_resource_tools.py \
+    tests/test_skill_script_tools.py \
+    tests/test_companion_mcp.py \
+    tests/test_prompt_library.py \
+    tests/test_node_memory_store.py \
+    tests/test_mobile_api.py \
+    tests/test_tool_stats_store.py \
+    tests/test_provider_tool_call_protocol.py
+fi
+
+echo
+echo "[OK] AgentPark Linux acceptance passed"

--- a/scripts/restart_aitools.py
+++ b/scripts/restart_aitools.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+
+
+def _pid_path(workspace_root: str) -> str:
+    return os.path.join(os.path.abspath(workspace_root), ".runtime", "aitools-server.pid")
+
+
+def _read_payload(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("pid file payload must be a JSON object")
+    return payload
+
+
+def _payload_pid(payload: dict) -> int:
+    return int(payload.get("pid") or 0)
+
+
+def _process_exists(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _cmdline_path(pid: int) -> str:
+    return os.path.join("/proc", str(pid), "cmdline")
+
+
+def _read_process_cmdline(pid: int) -> list[str]:
+    try:
+        with open(_cmdline_path(pid), "rb") as handle:
+            raw = handle.read()
+    except FileNotFoundError:
+        return []
+    parts = [item.decode("utf-8", errors="replace") for item in raw.split(b"\0") if item]
+    return parts
+
+
+def _is_expected_server_process(pid: int, payload: dict, workspace_root: str) -> bool:
+    if not _process_exists(pid):
+        return False
+
+    cmdline = _read_process_cmdline(pid)
+    if not cmdline:
+        return False
+
+    normalized_root = os.path.abspath(workspace_root)
+    payload_root = os.path.abspath(str(payload.get("workspace_root") or normalized_root))
+    if payload_root != normalized_root:
+        return False
+
+    joined = "\0".join(cmdline)
+    has_fast_api_module = "\0-m\0src.fast_api" in joined or any(part.endswith("src/fast_api.py") for part in cmdline)
+    has_workspace_arg = normalized_root in cmdline or f"--workspace-root\0{normalized_root}" in joined
+    return has_fast_api_module and has_workspace_arg
+
+
+def _terminate(pid: int, timeout: float) -> bool:
+    if not _process_exists(pid):
+        return True
+    os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_exists(pid):
+            return True
+        time.sleep(0.05)
+    if _process_exists(pid):
+        os.kill(pid, signal.SIGKILL)
+    return not _process_exists(pid)
+
+
+def stop_workspace_server(workspace_root: str, timeout: float) -> int:
+    path = _pid_path(workspace_root)
+    if not os.path.isfile(path):
+        print(f"[INFO] No server pid file found: {path}")
+        return 0
+    try:
+        payload = _read_payload(path)
+        pid = _payload_pid(payload)
+    except Exception as exc:
+        print(f"[ERROR] Failed to read pid file {path}: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    if pid <= 0:
+        print(f"[ERROR] Invalid pid in {path}: {pid}", file=sys.stderr)
+        return 1
+    if not _is_expected_server_process(pid, payload, workspace_root):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        print(f"[INFO] Removed stale server pid file: {path}")
+        return 0
+    if not _terminate(pid, timeout):
+        print(f"[ERROR] Failed to stop server process pid={pid}", file=sys.stderr)
+        return 1
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    print(f"[INFO] Stopped server process pid={pid}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace-root", default=os.getcwd())
+    parser.add_argument("--stop-only", action="store_true")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    args = parser.parse_args(argv)
+    if not args.stop_only:
+        parser.error("only --stop-only is supported")
+    return stop_workspace_server(args.workspace_root, args.timeout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli_commands/companion_prompt.py
+++ b/src/cli_commands/companion_prompt.py
@@ -18,14 +18,14 @@ EXIT_COMMANDS = {"/exit", "/quit", "exit", "quit"}
 COMMANDS = [
     ("/help", "Show available companion commands"),
     ("/status", "Show provider, config, memory, and runtime paths"),
-    ("/restart", "Run Restart.bat and exit this CLI session"),
+    ("/restart", "Run the platform restart script and exit this CLI session"),
     ("/clear", "Clear the terminal transcript"),
     ("/exit", "Quit the companion CLI"),
 ]
 HELP_TEXT = """Commands:
   /help    Show this help
   /status  Show companion runtime paths and provider config
-  /restart Run Restart.bat and exit this CLI session
+  /restart Run the platform restart script and exit this CLI session
   /clear   Clear the terminal
   /exit    Quit
 
@@ -289,7 +289,8 @@ class PromptCompanionTerminal:
         except Exception as exc:
             self._print_error(f"restart failed: {type(exc).__name__}: {exc}")
             return False
-        self._print_block("status", f"Started Restart.bat\nscript: {launched.script_path}\npid: {launched.pid}")
+        label = launched.label or "restart script"
+        self._print_block("status", f"Started {label}\nscript: {launched.script_path}\npid: {launched.pid}")
         return True
 
     def _clear(self) -> None:

--- a/src/cli_commands/companion_restart.py
+++ b/src/cli_commands/companion_restart.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 from dataclasses import dataclass
+from typing import Sequence
 
 from src.web_backend import runtime_paths
 
@@ -14,19 +15,49 @@ RESTART_EXIT_CODE = 43
 class RestartLaunch:
     script_path: str
     pid: int
+    label: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.label:
+            object.__setattr__(self, "label", restart_script_label(self.script_path))
+
+
+def resolve_restart_script(root: str | None = None) -> str:
+    runtime_root = os.path.abspath(root or runtime_paths._get_runtime_root())
+    script_name = "Restart.bat" if os.name == "nt" else "Restart.sh"
+    script_path = os.path.join(runtime_root, script_name)
+    if not os.path.isfile(script_path):
+        raise FileNotFoundError(f"{script_name} does not exist: {script_path}")
+    return script_path
+
+
+def restart_script_label(script_path: str) -> str:
+    return os.path.basename(str(script_path or "").strip()) or "restart script"
+
+
+def build_restart_command(script_path: str) -> Sequence[str]:
+    if os.name == "nt":
+        return ["cmd.exe", "/c", script_path]
+    return [script_path]
+
+
+def launch_restart_script() -> RestartLaunch:
+    root = runtime_paths._get_runtime_root()
+    script_path = resolve_restart_script(root)
+    creationflags = 0
+    popen_kwargs = {}
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NEW_CONSOLE", 0)
+        popen_kwargs["creationflags"] = creationflags
+    else:
+        popen_kwargs["start_new_session"] = True
+    proc = subprocess.Popen(
+        list(build_restart_command(script_path)),
+        cwd=root,
+        **popen_kwargs,
+    )
+    return RestartLaunch(script_path=script_path, pid=int(proc.pid), label=restart_script_label(script_path))
 
 
 def launch_restart_bat() -> RestartLaunch:
-    root = runtime_paths._get_runtime_root()
-    script_path = os.path.join(root, "Restart.bat")
-    if not os.path.isfile(script_path):
-        raise FileNotFoundError(f"Restart.bat does not exist: {script_path}")
-    creationflags = 0
-    if os.name == "nt":
-        creationflags = getattr(subprocess, "CREATE_NEW_CONSOLE", 0)
-    proc = subprocess.Popen(
-        ["cmd.exe", "/c", script_path] if os.name == "nt" else [script_path],
-        cwd=root,
-        creationflags=creationflags,
-    )
-    return RestartLaunch(script_path=script_path, pid=int(proc.pid))
+    return launch_restart_script()

--- a/src/cli_commands/companion_terminal.py
+++ b/src/cli_commands/companion_terminal.py
@@ -16,7 +16,7 @@ EXIT_COMMANDS = {"/exit", "/quit", "exit", "quit"}
 HELP_TEXT = """Commands:
   /help    Show this help
   /status  Show companion runtime paths and provider config
-  /restart Run Restart.bat and exit this CLI session
+  /restart Run the platform restart script and exit this CLI session
   /clear   Clear the terminal
   /exit    Quit
 
@@ -163,7 +163,8 @@ class PlainCompanionTerminal:
         except Exception as exc:
             self._print_error(f"restart failed: {type(exc).__name__}: {exc}")
             return False
-        self._print_block("status", f"Started Restart.bat\nscript: {launched.script_path}\npid: {launched.pid}")
+        label = launched.label or "restart script"
+        self._print_block("status", f"Started {label}\nscript: {launched.script_path}\npid: {launched.pid}")
         return True
 
     def _clear(self) -> None:

--- a/src/cli_commands/companion_tui.py
+++ b/src/cli_commands/companion_tui.py
@@ -22,7 +22,7 @@ TurnRunner = Callable[..., dict[str, Any]]
 HELP_LINES = [
     "/help      show commands",
     "/status    show config and runtime paths",
-    "/restart  run Restart.bat and exit this CLI session",
+    "/restart  run the platform restart script and exit this CLI session",
     "/clear     clear transcript",
     "/exit      quit",
     "Enter      submit",
@@ -320,9 +320,8 @@ class CompanionTui:
             self.state.transcript.append(TranscriptItem(role="error", text=f"restart failed: {type(exc).__name__}: {exc}"))
             self.state.status = "restart failed"
             return
-        self.state.transcript.append(
-            TranscriptItem(role="status", text=f"Started Restart.bat\nscript: {launched.script_path}\npid: {launched.pid}")
-        )
+        label = launched.label or "restart script"
+        self.state.transcript.append(TranscriptItem(role="status", text=f"Started {label}\nscript: {launched.script_path}\npid: {launched.pid}"))
         self.state.status = "restart launched"
         self.state.restart_requested = True
         self.state.should_exit = True

--- a/src/providers/curl_transport.py
+++ b/src/providers/curl_transport.py
@@ -24,6 +24,10 @@ class CurlTransportError(ProviderTransportError):
 
 
 class CurlHttpTransport:
+    @staticmethod
+    def _curl_executable() -> str:
+        return "curl.exe" if os.name == "nt" else "curl"
+
     def _cancel_source(self):
         return getattr(self, "cancel_event", None) or getattr(self, "cancel_check", None)
 
@@ -39,7 +43,7 @@ class CurlHttpTransport:
             with self._provider_pressure_slot():
                 proc = subprocess.run(
                     [
-                        "curl.exe",
+                        self._curl_executable(),
                         "--silent",
                         "--show-error",
                         "--location",
@@ -67,7 +71,7 @@ class CurlHttpTransport:
         connect_timeout = max(1, min(15, timeout_val))
         try:
             cmd = [
-                "curl.exe",
+                self._curl_executable(),
                 "--silent",
                 "--show-error",
                 "--location",
@@ -285,10 +289,10 @@ class CurlHttpTransport:
         except Exception:
             pass
 
-    @staticmethod
-    def _build_curl_post_command(*, url, headers, payload_path, timeout_val, connect_timeout, marker, no_buffer):
+    @classmethod
+    def _build_curl_post_command(cls, *, url, headers, payload_path, timeout_val, connect_timeout, marker, no_buffer):
         cmd = [
-            "curl.exe",
+            cls._curl_executable(),
             "--silent",
             "--show-error",
             "--location",

--- a/src/web_backend/core_system_api.py
+++ b/src/web_backend/core_system_api.py
@@ -5,6 +5,9 @@ import threading
 from fastapi import HTTPException, Request
 
 from src.provider_options import build_provider_support_list
+from src.cli_commands.companion_restart import build_restart_command
+from src.cli_commands.companion_restart import resolve_restart_script
+from src.cli_commands.companion_restart import restart_script_label
 
 from .domain_base import DomainBase
 from .runtime_paths import _get_runtime_root
@@ -14,10 +17,8 @@ from .system_file_api import FileSystemApiMixin
 class SystemApiDomain(FileSystemApiMixin, DomainBase):
     def restart_server(self):
         runtime_root = _get_runtime_root()
-        restart_path = os.path.join(runtime_root, "Restart.bat")
-        if not os.path.isfile(restart_path):
-            raise HTTPException(status_code=404, detail="Restart.bat not found")
         try:
+            restart_path = resolve_restart_script(runtime_root)
             if os.name == "nt":
                 subprocess.Popen(
                     ["cmd.exe", "/c", "start", "AgentPark Restart", restart_path],
@@ -26,10 +27,12 @@ class SystemApiDomain(FileSystemApiMixin, DomainBase):
                     creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
                 )
             else:
-                subprocess.Popen([restart_path], cwd=runtime_root, start_new_session=True)
+                subprocess.Popen(list(build_restart_command(restart_path)), cwd=runtime_root, start_new_session=True)
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
-        return {"ok": True}
+        return {"ok": True, "script": restart_path, "label": restart_script_label(restart_path)}
 
     def exit_server(self, request: Request):
         exit_func = getattr(request.app.state, "request_workspace_exit", None)

--- a/src/web_backend/graph_node_store.py
+++ b/src/web_backend/graph_node_store.py
@@ -3,7 +3,7 @@ import os
 
 from . import runtime_paths, state_store
 from .service_host import HostBoundService
-from .node_config_service import read_node_config_strict, write_node_config
+from .node_config_service import read_node_config_optional, read_node_config_strict, write_node_config
 from .node_state_machine import parse_node_state
 from .shared import (
     _recover_node_config_startup_state,
@@ -14,7 +14,7 @@ from .route_parser import NodeRouteParser
 from .node_memory_store import append_node_memory_entry
 from .node_memory_store import append_node_tool_call_entry
 from .node_memory_store import ensure_node_memory_files
-from .node_config_errors import NodeConfigWriteError
+from .node_config_errors import NodeConfigReadError, NodeConfigWriteError
 from .node_metadata_reader import load_node_instance
 from .node_metadata_reader import read_node_ports
 from .node_metadata_reader import run_node_on_create
@@ -104,28 +104,59 @@ class GraphNodeStore(HostBoundService):
     def _node_dir(self, graph_id: str, node_id: str) -> str:
         graph_id = self._sanitize_graph_id(graph_id)
         safe_id = self._sanitize_node_id(node_id)
-        return os.path.join(self._graph_dir(graph_id), safe_id)
+        base_dir = self._graph_dir(graph_id)
+        storage_id, _canonical_id = self._resolve_existing_node_location(graph_id, safe_id)
+        return os.path.join(base_dir, storage_id or safe_id)
 
     def _resolve_existing_node_id(self, graph_id: str, node_id: str) -> str:
         safe_graph_id = self._sanitize_graph_id(graph_id)
         safe_node_id = self._sanitize_node_id(node_id)
         if not safe_node_id:
             return safe_node_id
+        _storage_id, canonical_id = self._resolve_existing_node_location(safe_graph_id, safe_node_id)
+        return canonical_id or safe_node_id
+
+    def _resolve_existing_node_location(self, graph_id: str, node_id: str) -> tuple[str, str]:
+        safe_graph_id = self._sanitize_graph_id(graph_id)
+        safe_node_id = self._sanitize_node_id(node_id)
+        if not safe_node_id:
+            return safe_node_id, safe_node_id
         base_dir = self._graph_dir(safe_graph_id)
         if not base_dir or not os.path.isdir(base_dir):
-            return safe_node_id
+            return safe_node_id, safe_node_id
         try:
-            entries = [entry for entry in os.listdir(base_dir) if entry != "agents"]
+            entries = sorted(entry for entry in os.listdir(base_dir) if entry != "agents")
         except OSError:
-            return safe_node_id
+            return safe_node_id, safe_node_id
 
-        def has_config(entry: str) -> bool:
-            return os.path.exists(os.path.join(base_dir, entry, "config.json"))
-
+        candidates: list[tuple[str, str]] = []
         for entry in entries:
-            if entry == safe_node_id and has_config(entry):
-                return entry
-        return safe_node_id
+            config_path = os.path.join(base_dir, entry, "config.json")
+            if not os.path.isfile(config_path):
+                continue
+            try:
+                config = read_node_config_optional(config_path)
+            except NodeConfigReadError:
+                config = {}
+            canonical_id = self._sanitize_node_id((config or {}).get("node_id")) or entry
+            candidates.append((entry, canonical_id))
+
+        for storage_id, canonical_id in candidates:
+            if canonical_id == safe_node_id:
+                return storage_id, canonical_id
+        for storage_id, canonical_id in candidates:
+            if storage_id == safe_node_id:
+                return storage_id, canonical_id
+
+        folded_id = safe_node_id.casefold()
+        folded_matches = [
+            (storage_id, canonical_id)
+            for storage_id, canonical_id in candidates
+            if canonical_id.casefold() == folded_id or storage_id.casefold() == folded_id
+        ]
+        if len(folded_matches) == 1:
+            return folded_matches[0]
+        return safe_node_id, safe_node_id
 
     def _node_config_path(self, node_id: str, graph_id: str) -> str:
         node_dir = self._node_dir(graph_id, node_id)

--- a/tests/test_curl_transport.py
+++ b/tests/test_curl_transport.py
@@ -1,0 +1,31 @@
+from src.providers import curl_transport
+from src.providers.curl_transport import CurlHttpTransport
+
+
+def test_curl_executable_uses_plain_curl_on_posix(monkeypatch):
+    monkeypatch.setattr(curl_transport.os, "name", "posix")
+
+    assert CurlHttpTransport._curl_executable() == "curl"
+
+
+def test_curl_executable_uses_curl_exe_on_windows(monkeypatch):
+    monkeypatch.setattr(curl_transport.os, "name", "nt")
+
+    assert CurlHttpTransport._curl_executable() == "curl.exe"
+
+
+def test_curl_post_command_uses_platform_executable(monkeypatch):
+    monkeypatch.setattr(curl_transport.os, "name", "posix")
+
+    command = CurlHttpTransport._build_curl_post_command(
+        url="https://example.test/v1/responses",
+        headers={"Authorization": "Bearer token"},
+        payload_path="/tmp/request.json",
+        timeout_val=60,
+        connect_timeout=15,
+        marker="__STATUS__",
+        no_buffer=False,
+    )
+
+    assert command[0] == "curl"
+    assert "curl.exe" not in command


### PR DESCRIPTION
> [!NOTE]
> This focused Linux-runtime PR is the recommended low-risk option. A broader alternative is available in #2. The two PRs overlap and must not both be merged.

## Summary

- add Linux build, server, CLI, and restart entry points while keeping the existing Windows entry points
- select platform-specific restart scripts and curl executables without changing the Windows command path
- use the automatic screenshot backend so Linux can fall back to pyautogui while Windows still tries GDI first
- add repeatable Linux merge acceptance checks and dual-platform documentation
- resolve node storage directories separately from canonical node IDs on case-sensitive filesystems

## Windows compatibility

- `build_and_run.bat`, `Restart.bat`, PowerShell helpers, desktop pet, and Windows packaging remain unchanged
- Windows restart still uses `cmd.exe`, `Restart.bat`, and the existing process creation flags
- Windows curl still resolves to `curl.exe`
- README continues to identify Windows as the primary target and documents Linux as an additional supported runtime

This PR intentionally excludes the OpenAI image-generation work, provider-specific Responses compatibility changes, and the node-config fullscreen UI from the Linux development branch.

## Validation

- `scripts/acceptance_linux.sh --full`
  - backend import smoke passed
  - WebUI TypeScript and Vite production build passed
  - 103 core contract tests passed
  - 138 skills/MCP/plugin/tool/memory/mobile/provider tests passed
- full pytest run: 952 passed, 2 skipped
- the remaining 4 Linux failures reproduce unchanged on upstream `f28273d`:
  - PowerShell-specific large console stdout test
  - private-network CORS preflight test
  - two runtime-event persistence tests

No real provider requests or API keys are included in this PR.
